### PR TITLE
Agregar modo oscuro con variables CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
         <li><a href="#procesos"><i class="fas fa-industry"></i> Procesos</a></li>
         <li><a href="#impactos"><i class="fas fa-leaf"></i> Impactos</a></li>
         <li><a href="#tecnologia"><i class="fas fa-microchip"></i> Tecnología</a></li>
+        <li><a href="#" id="theme-toggle" aria-label="Cambiar modo de color"><i class="fas fa-moon"></i></a></li>
       </ul>
     </div>
   </nav>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -10,6 +10,15 @@
   --accent-1:   #C07A00;
   --accent-2:   #A67B5B;
   --shadow:     rgba(0, 0, 0, 0.05);
+
+  /* Colores modo oscuro */
+  --bg-page-dark:   #1e1e1e;
+  --bg-header-dark: #1b2735;
+  --bg-card-dark:   #2c2c2c;
+  --text-main-dark: #e0e0e0;
+  --accent-1-dark:  #ffb74d;
+  --accent-2-dark:  #d7ccc8;
+  --shadow-dark:    rgba(0, 0, 0, 0.5);
 }
 
 * {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -63,4 +63,39 @@ window.addEventListener('scroll', () => {
 topButton.addEventListener('click', (e) => {
   e.preventDefault();
   window.scrollTo({ top: 0, behavior: 'smooth' });
-}); 
+});
+
+// Modo oscuro
+const themeToggle = document.getElementById('theme-toggle');
+const root = document.documentElement;
+const rootStyles = getComputedStyle(root);
+
+const lightTheme = {
+  '--bg-page': rootStyles.getPropertyValue('--bg-page').trim(),
+  '--bg-header': rootStyles.getPropertyValue('--bg-header').trim(),
+  '--bg-card': rootStyles.getPropertyValue('--bg-card').trim(),
+  '--text-main': rootStyles.getPropertyValue('--text-main').trim(),
+  '--accent-1': rootStyles.getPropertyValue('--accent-1').trim(),
+  '--accent-2': rootStyles.getPropertyValue('--accent-2').trim(),
+  '--shadow': rootStyles.getPropertyValue('--shadow').trim()
+};
+
+const darkTheme = {
+  '--bg-page': rootStyles.getPropertyValue('--bg-page-dark').trim(),
+  '--bg-header': rootStyles.getPropertyValue('--bg-header-dark').trim(),
+  '--bg-card': rootStyles.getPropertyValue('--bg-card-dark').trim(),
+  '--text-main': rootStyles.getPropertyValue('--text-main-dark').trim(),
+  '--accent-1': rootStyles.getPropertyValue('--accent-1-dark').trim(),
+  '--accent-2': rootStyles.getPropertyValue('--accent-2-dark').trim(),
+  '--shadow': rootStyles.getPropertyValue('--shadow-dark').trim()
+};
+
+themeToggle.addEventListener('click', (e) => {
+  e.preventDefault();
+  const isDark = document.body.classList.toggle('dark-mode');
+  const theme = isDark ? darkTheme : lightTheme;
+  Object.keys(theme).forEach(prop => {
+    root.style.setProperty(prop, theme[prop]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Añade variables alternativas para tema oscuro y almacena colores iniciales
- Incorpora un botón en la barra de navegación para cambiar de tema
- Ajusta las variables CSS mediante JavaScript al alternar el modo oscuro

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ec6611c83209987f6fc6f0958c5