### PR TITLE
feat: add keyboard navigation for lightbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,15 +294,15 @@
   </div>
 
   <!-- LIGHTBOX -->
-  <div id="lightbox">
+  <div id="lightbox" role="dialog" aria-modal="true" aria-hidden="true" aria-label="Galería de imágenes. Usa las flechas del teclado para navegar y Escape para cerrar.">
     <div class="lb-content">
-      <button class="lb-close">&times;</button>
-      <button class="lb-nav lb-prev">&#10094;</button>
+      <button class="lb-close" aria-label="Cerrar">&times;</button>
+      <button class="lb-nav lb-prev" aria-label="Anterior">&#10094;</button>
       <div class="lb-slide">
         <img id="lb-img" src="" alt="Slide grande">
         <div id="lb-info"></div>
       </div>
-      <button class="lb-nav lb-next">&#10095;</button>
+      <button class="lb-nav lb-next" aria-label="Siguiente">&#10095;</button>
     </div>
   </div>
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -13,12 +13,32 @@ const images = Array.from(document.querySelectorAll('.question img'));
 
 let currentIndex = 0;
 
+// Función para cerrar el lightbox
+function closeLightbox() {
+  lightbox.style.display = 'none';
+  document.body.style.overflow = 'auto';
+  lightbox.setAttribute('aria-hidden', 'true');
+}
+
+// Funciones para navegar entre imágenes
+function showPrev() {
+  currentIndex = (currentIndex - 1 + images.length) % images.length;
+  updateLightbox();
+}
+
+function showNext() {
+  currentIndex = (currentIndex + 1) % images.length;
+  updateLightbox();
+}
+
 // Función para abrir el lightbox
 function openLightbox(index) {
   currentIndex = index;
   updateLightbox();
   lightbox.style.display = 'flex';
   document.body.style.overflow = 'hidden';
+  lightbox.setAttribute('aria-hidden', 'false');
+  lbClose.focus();
 }
 
 // Función para actualizar el contenido del lightbox
@@ -29,19 +49,25 @@ function updateLightbox() {
 }
 
 // Event listeners para los botones de navegación
-lbClose.addEventListener('click', () => {
-  lightbox.style.display = 'none';
-  document.body.style.overflow = 'auto';
-});
+lbClose.addEventListener('click', closeLightbox);
+lbPrev.addEventListener('click', showPrev);
+lbNext.addEventListener('click', showNext);
 
-lbPrev.addEventListener('click', () => {
-  currentIndex = (currentIndex - 1 + images.length) % images.length;
-  updateLightbox();
-});
-
-lbNext.addEventListener('click', () => {
-  currentIndex = (currentIndex + 1) % images.length;
-  updateLightbox();
+// Navegación con el teclado
+document.addEventListener('keydown', (e) => {
+  if (lightbox.style.display === 'flex') {
+    switch (e.key) {
+      case 'Escape':
+        closeLightbox();
+        break;
+      case 'ArrowLeft':
+        showPrev();
+        break;
+      case 'ArrowRight':
+        showNext();
+        break;
+    }
+  }
 });
 
 // Event listeners para las imágenes


### PR DESCRIPTION
## Summary
- enable arrow and escape key navigation for the lightbox gallery
- focus on the lightbox when opened to capture key events
- document lightbox keyboard support with aria labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ececbc08320b843be62386ca8a2