### PR TITLE
Corregir contraste del modo oscuro

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -19,6 +19,10 @@
   --accent-1-dark:  #ffb74d;
   --accent-2-dark:  #d7ccc8;
   --shadow-dark:    rgba(0, 0, 0, 0.5);
+
+  /* Texto sobre fondos oscuros */
+  --text-inverse:      #ffffff;
+  --text-inverse-dark: #e0e0e0;
 }
 
 * {
@@ -36,7 +40,7 @@ body {
 /* Header */
 header {
   background: var(--bg-header);
-  color: var(--bg-card);
+  color: var(--text-inverse);
   text-align: center;
   padding: 2rem 1rem;
   box-shadow: 0 2px 8px var(--shadow);
@@ -78,8 +82,8 @@ header p {
   gap: 1rem;
 }
 
-.main-nav a {
-  color: var(--bg-card);
+  .main-nav a {
+  color: var(--text-inverse);
   text-decoration: none;
   padding: 1rem;
   display: flex;
@@ -224,9 +228,9 @@ main {
 }
 
 /* Footer */
-footer {
+  footer {
   background-color: var(--bg-header);
-  color: var(--bg-card);
+  color: var(--text-inverse);
   padding: 2rem 1rem;
   border-top: 4px solid var(--accent-1);
 }
@@ -268,8 +272,8 @@ footer {
   text-align: center;
 }
 
-.footer-section a {
-  color: var(--bg-card);
+  .footer-section a {
+  color: var(--text-inverse);
   text-decoration: none;
   transition: color 0.3s;
 }
@@ -284,8 +288,8 @@ footer {
   margin-top: 1rem;
 }
 
-.social-links a {
-  color: var(--bg-card);
+  .social-links a {
+  color: var(--text-inverse);
   font-size: 1.5rem;
   transition: all 0.3s;
   width: 40px;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -103,7 +103,8 @@ const lightTheme = {
   '--text-main': rootStyles.getPropertyValue('--text-main').trim(),
   '--accent-1': rootStyles.getPropertyValue('--accent-1').trim(),
   '--accent-2': rootStyles.getPropertyValue('--accent-2').trim(),
-  '--shadow': rootStyles.getPropertyValue('--shadow').trim()
+  '--shadow': rootStyles.getPropertyValue('--shadow').trim(),
+  '--text-inverse': rootStyles.getPropertyValue('--text-inverse').trim()
 };
 
 const darkTheme = {
@@ -113,7 +114,8 @@ const darkTheme = {
   '--text-main': rootStyles.getPropertyValue('--text-main-dark').trim(),
   '--accent-1': rootStyles.getPropertyValue('--accent-1-dark').trim(),
   '--accent-2': rootStyles.getPropertyValue('--accent-2-dark').trim(),
-  '--shadow': rootStyles.getPropertyValue('--shadow-dark').trim()
+  '--shadow': rootStyles.getPropertyValue('--shadow-dark').trim(),
+  '--text-inverse': rootStyles.getPropertyValue('--text-inverse-dark').trim()
 };
 
 themeToggle.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- Añade variables `--text-inverse` para texto claro en modo oscuro.
- Ajusta encabezado, navegación y pie de página para usar el nuevo color.
- Actualiza el script de cambio de tema para manejar la nueva variable.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e665151fc83209643d92d7ab31b00